### PR TITLE
FIX: rotate : name of `rotate_tools` structure error 

### DIFF
--- a/src/load_Image/rotate.c
+++ b/src/load_Image/rotate.c
@@ -32,7 +32,7 @@ void apply_rotation(GtkWidget* image, enum e_rotate_type r_type, double degree,
                     guchar* filter(struct s_rotate_tools))
 {
     // Initialize our tools
-    struct rotate_tools tools;
+    struct s_rotate_tools tools;
     
     // Transform degrees in radient
     tools.degree = 3.14159265358979323846264338*degree/180;

--- a/src/load_Image/rotate.h
+++ b/src/load_Image/rotate.h
@@ -67,7 +67,7 @@ struct s_rotate_tools
  ** \param fun function to apply on each pixel
  */
 void apply_rotation(GtkWidget* image, enum e_rotate_type r_type, double degree,
-                guchar* filter(struct r_rotate_tools));
+                guchar* filter(struct s_rotate_tools));
 
 
 /**


### PR DESCRIPTION
2 structure type not rename in #9 

**FIX**:
-`src/../rotate.c`: bug fix